### PR TITLE
fix 'local variable 'user' referenced before assignment' error

### DIFF
--- a/config_k8s_flocker.py
+++ b/config_k8s_flocker.py
@@ -21,6 +21,8 @@ class UsageError(Exception):
 def main(reactor, configFile):
     c = Configurator(configFile=configFile)
 
+    user = ""
+    
     if c.config["os"] == "ubuntu":
         user = "ubuntu"
     elif c.config["os"] == "centos":


### PR DESCRIPTION
I was getting the following error:

```
main function encountered error
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 382, in callback
    self._startRunCallbacks(result)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 490, in _startRunCallbacks
    self._runCallbacks()
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 577, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1155, in gotResult
    _inlineCallbacks(r, g, deferred)
--- <exception caught here> ---
  File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 1099, in _inlineCallbacks
    result = g.send(result)
  File "/srv/projects/kube-aws-flocker/config_k8s_flocker.py", line 66, in main
    if user == "ubuntu":
exceptions.UnboundLocalError: local variable 'user' referenced before assignment
```

This PR fixed it :-)
